### PR TITLE
Accomodate SCP 079 camera rotation in AFK Check

### DIFF
--- a/UltimateAFK/AFKComponent.cs
+++ b/UltimateAFK/AFKComponent.cs
@@ -75,7 +75,7 @@ namespace UltimateAFK
             }
 
             var CurrentPos = ply.Position;
-            var CurrentAngle = (isScp079) ? ((Scp079Role) ply.Role).Camera.Position : new Vector3(ply.Rotation.x, ply.Rotation.y); 
+            var CurrentAngle = (isScp079) ? ((Scp079Role) ply.Role).Camera.HeadRotation.eulerAngles : new Vector3(ply.Rotation.x, ply.Rotation.y); 
 
             if (CurrentPos != AFKLastPosition || CurrentAngle != AFKLastAngle || scp096TryNotToCry)
             {


### PR DESCRIPTION
Someone reported that SCP079's camera rotation is not taking into account when checking for AFK status on players.
During updates the Position of the SCP079 have changed and now it just returns the origin point for the cameras instead of the position of the rotated camera (this is an educated guess due to how it's handled and accounting for the issue mentioned)

Now we instead check for the HeadRotation (.eulerAngles for Vector3) which should mean that moving the camera should remove the AFK warning